### PR TITLE
Support existingClaims and random Django secret in k8s secret

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,8 +83,8 @@ For additional configuration of the Bitnami PostgreSQL and Redis, please check t
 | Name | Description | Type | Default Value |
 |------|-------------|------|---------------|
 | `app.persistence.enabled` | Whether to enable persistent storage. If `false`, the options from below are ignored | Boolean | `false` |
-| `app.persistence.existingClaim.media` | Name of the pvc for the media data when existingClaim is enabled  | String | `Nil` |
-| `app.persistence.existingClaim.static` | Name of the pvc for the static data when existingClaim is enabled  | String | `Nil` |
+| `app.persistence.existingClaim.media` | Name of the pvc for the media data when existingClaim is enabled  | String | `null` |
+| `app.persistence.existingClaim.static` | Name of the pvc for the static data when existingClaim is enabled  | String | `null` |
 | `app.persistence.existingClaim.enabled` | Whether to use a existing persistent storage claim. If `false`, the options from below are ignored | Boolean | `false` |
 | `app.persistence.storageClass` | StorageClass for the PVCs | String | `""` |
 | `app.persistence.accessModes` | Access modes for the PVCs | Array | `["ReadWriteMany"]` |

--- a/README.md
+++ b/README.md
@@ -83,10 +83,14 @@ For additional configuration of the Bitnami PostgreSQL and Redis, please check t
 | Name | Description | Type | Default Value |
 |------|-------------|------|---------------|
 | `app.persistence.enabled` | Whether to enable persistent storage. If `false`, the options from below are ignored | Boolean | `false` |
+| `app.persistence.existingClaim.media` | Name of the pvc for the media data when existingClaim is enabled  | String | `Nil` |
+| `app.persistence.existingClaim.static` | Name of the pvc for the static data when existingClaim is enabled  | String | `Nil` |
+| `app.persistence.existingClaim.enabled` | Whether to use a existing persistent storage claim. If `false`, the options from below are ignored | Boolean | `false` |
 | `app.persistence.storageClass` | StorageClass for the PVCs | String | `""` |
 | `app.persistence.accessModes` | Access modes for the PVCs | Array | `["ReadWriteMany"]` |
 | `app.persistence.size` | PVC size | String | `8Gi` |
 | `app.persistence.annotations` | Annotations to attach to the persistence objects (PVC and PV) | Dictionary | `{}` |
+| `app.persistence.enabled` | Whether to enable persistent storage. If `false`, the options from below are ignored | Boolean | `false` |
 
 ### Application Resources
 

--- a/charts/wger/Chart.yaml
+++ b/charts/wger/Chart.yaml
@@ -1,6 +1,6 @@
 ---
 apiVersion: v2
-version: 0.1.3
+version: 0.1.4-rc.1
 appVersion: 2.1.0
 name: wger
 description: A Helm chart for Wger installation on Kubernetes

--- a/charts/wger/templates/deployment.yaml
+++ b/charts/wger/templates/deployment.yaml
@@ -93,12 +93,12 @@ spec:
             - -c
             - until nc -zvw10 {{.Release.Name}}-postgresql {{ .Values.postgresql.global.postgresql.service.ports.postgresql }}; do echo "Waiting for postgres service ({{.Release.Name}}-postgresql:{{ .Values.postgresql.global.postgresql.service.ports.postgresql }}) "; sleep 2; done &&
               until nc -zvw10 {{.Release.Name}}-redis-master {{ .Values.redis.master.containerPort }}; do echo "Waiting for redis service ({{.Release.Name}}-redis-master:{{ .Values.redis.master.containerPort }})"; sleep 2; done
-      {{- if or (.Values.app.persistence.enabled) (.Values.app.existingClaim.enabled) }}
+      {{- if .Values.app.persistence.enabled }}
       volumes:
         - name: wger-media
           persistentVolumeClaim:
-            claimName: {{ .Values.app.existingClaim.media | default "wger-media" | quote }}
+            claimName: {{ .Values.app.persistence.existingClaim.media | default "wger-media" | quote }}
         - name: wger-static
           persistentVolumeClaim:
-            claimName: {{ .Values.app.existingClaim.static | default "wger-static" | quote }}
+            claimName: {{ .Values.app.persistence.existingClaim.static | default "wger-static" | quote }}
       {{- end }}

--- a/charts/wger/templates/deployment.yaml
+++ b/charts/wger/templates/deployment.yaml
@@ -93,12 +93,12 @@ spec:
             - -c
             - until nc -zvw10 {{.Release.Name}}-postgresql {{ .Values.postgresql.global.postgresql.service.ports.postgresql }}; do echo "Waiting for postgres service ({{.Release.Name}}-postgresql:{{ .Values.postgresql.global.postgresql.service.ports.postgresql }}) "; sleep 2; done &&
               until nc -zvw10 {{.Release.Name}}-redis-master {{ .Values.redis.master.containerPort }}; do echo "Waiting for redis service ({{.Release.Name}}-redis-master:{{ .Values.redis.master.containerPort }})"; sleep 2; done
-      {{- if .Values.app.persistence.enabled }}
+      {{- if or (.Values.app.persistence.enabled) (.Values.app.existingClaim.enabled) }}
       volumes:
         - name: wger-media
           persistentVolumeClaim:
-            claimName: wger-media
+            claimName: {{ .Values.app.existingClaim.media | default "wger-media" | quote }}
         - name: wger-static
           persistentVolumeClaim:
-            claimName: wger-static
+            claimName: {{ .Values.app.existingClaim.static | default "wger-static" | quote }}
       {{- end }}

--- a/charts/wger/templates/deployment.yaml
+++ b/charts/wger/templates/deployment.yaml
@@ -75,6 +75,11 @@ spec:
               value: "True"
             - name: DJANGO_MEDIA_ROOT
               value: /home/wger/media
+            - name: SECRET_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.app.django.secret.name | default .Release.Name }}
+                  key: secret-key
             {{- if .Values.ingress.enabled }}
             - name: SITE_URL
               value: {{ .Values.ingress.url }}

--- a/charts/wger/templates/persistent-volume-claim.yaml
+++ b/charts/wger/templates/persistent-volume-claim.yaml
@@ -1,5 +1,6 @@
 # yamllint disable rule:document-start
 {{- if .Values.app.persistence.enabled }}
+{{- if not .Values.app.persistence.existingClaim.enabled }}
 ---
 apiVersion: v1
 kind: PersistentVolumeClaim
@@ -44,4 +45,5 @@ spec:
   {{- if .Values.app.persistence.storageClass }}
   storageClassName:  {{ .Values.app.persistence.storageClass | quote }}
   {{- end }}
+{{- end }}
 {{- end }}

--- a/charts/wger/templates/secret-django.yaml
+++ b/charts/wger/templates/secret-django.yaml
@@ -2,11 +2,11 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: django
+  name: {{ .Values.app.django.secret.name | default .Release.Name }}
   namespace: {{ .Release.Namespace }}
 stringData:
-  {{ if .Values.app.django.secretKey }}
-  secret-key: {{ .Values.app.django.secretKey | b64enc | quote }}
+  {{ if .Values.app.django.secret.secretKey }}
+  secret-key: {{ .Values.app.django.secret.secretKey | quote }}
   {{ else }}
-  secret-key: {{ randAlphaNum 32 | b64enc | quote }}
+  secret-key: {{ randAlphaNum 42 | quote }}
   {{ end }}

--- a/charts/wger/templates/secret-django.yaml
+++ b/charts/wger/templates/secret-django.yaml
@@ -1,0 +1,12 @@
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: django
+  namespace: {{ .Release.Namespace }}
+stringData:
+  {{ if .Values.app.django.secretKey }}
+  secret-key: {{ .Values.app.django.secretKey | b64enc | quote }}
+  {{ else }}
+  secret-key: {{ randAlphaNum 32 | b64enc | quote }}
+  {{ end }}

--- a/charts/wger/values.yaml
+++ b/charts/wger/values.yaml
@@ -13,10 +13,10 @@ app:
       - ReadWriteMany
     size: 8Gi
     annotations: {}
-  existingClaim:
-    enabled: false
-    media: null
-    static: null
+    existingClaim:
+      enabled: false
+      media: null
+      static: null
   resources:
     requests:
       memory: 128Mi

--- a/charts/wger/values.yaml
+++ b/charts/wger/values.yaml
@@ -15,8 +15,8 @@ app:
     annotations: {}
     existingClaim:
       enabled: false
-      media: null # if not set wger-media is taken
-      static: null # if not set wger-static is taken
+      media: null
+      static: null
   resources:
     requests:
       memory: 128Mi
@@ -26,8 +26,8 @@ app:
       cpu: 500m
   django:
     secret:
-      name: null # if not set .Release.Name is set
-      secretKey: null # if not set a random one is generated
+      name: null
+      secretKey: null
   environment:
     - name: TIME_ZONE
       value: UTC

--- a/charts/wger/values.yaml
+++ b/charts/wger/values.yaml
@@ -24,6 +24,8 @@ app:
     limits:
       memory: 512Mi
       cpu: 500m
+  django:
+    secretKey: null # if not set a random one is generated
   environment:
     - name: TIME_ZONE
       value: UTC
@@ -41,6 +43,25 @@ app:
       value: None
     - name: FROM_EMAIL
       value: test@test.com
+    - name: WGER_USE_GUNICORN
+      value: "False"
+    - name: SYNC_EXERCISES_ON_STARTUP
+      value: "False"
+    - name: DOWNLOAD_EXERCISE_IMAGES_ON_STARTUP
+      value: "False"
+    - name: ALLOW_REGISTRATION
+      value: "False"
+    - name: ALLOW_GUEST_USERS
+      value: "False"
+    - name: SECRET_KEY
+      valueFrom:
+        secretKeyRef:
+          name: django
+          key: secret-key
+    - name: CSRF_TRUSTED_ORIGINS
+      value: "http://127.0.0.1,http://localhost,https://localhost"
+    - name: DJANGO_DEBUG
+      value: "False"
 
 ingress:
   enabled: false

--- a/charts/wger/values.yaml
+++ b/charts/wger/values.yaml
@@ -15,8 +15,8 @@ app:
     annotations: {}
     existingClaim:
       enabled: false
-      media: null
-      static: null
+      media: null # if not set wger-media is taken
+      static: null # if not set wger-static is taken
   resources:
     requests:
       memory: 128Mi
@@ -25,7 +25,9 @@ app:
       memory: 512Mi
       cpu: 500m
   django:
-    secretKey: null # if not set a random one is generated
+    secret:
+      name: null # if not set .Release.Name is set
+      secretKey: null # if not set a random one is generated
   environment:
     - name: TIME_ZONE
       value: UTC
@@ -53,15 +55,8 @@ app:
       value: "False"
     - name: ALLOW_GUEST_USERS
       value: "False"
-    - name: SECRET_KEY
-      valueFrom:
-        secretKeyRef:
-          name: django
-          key: secret-key
     - name: CSRF_TRUSTED_ORIGINS
       value: "http://127.0.0.1,http://localhost,https://localhost"
-    - name: DJANGO_DEBUG
-      value: "False"
 
 ingress:
   enabled: false

--- a/charts/wger/values.yaml
+++ b/charts/wger/values.yaml
@@ -13,6 +13,10 @@ app:
       - ReadWriteMany
     size: 8Gi
     annotations: {}
+  existingClaim:
+    enabled: false
+    media: null
+    static: null
   resources:
     requests:
       memory: 128Mi


### PR DESCRIPTION
This will allow to use **existing PVC** for media and static.

The `SECRET_KEY` for Django salting can be defined in the values or left autocreated. It will be added into a k8s secret.