### PR TITLE
Add possibility to use nginx as proxy setup with gunicorn

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,8 +83,8 @@ For additional configuration of the Bitnami PostgreSQL and Redis, please check t
 | Name | Description | Type | Default Value |
 |------|-------------|------|---------------|
 | `app.persistence.enabled` | Whether to enable persistent storage. If `false`, the options from below are ignored | Boolean | `false` |
-| `app.persistence.existingClaim.media` | Name of the pvc for the media data when existingClaim is enabled  | String | `Nil` |
-| `app.persistence.existingClaim.static` | Name of the pvc for the static data when existingClaim is enabled  | String | `Nil` |
+| `app.persistence.existingClaim.media` | Name of the pvc for the media data when existingClaim is enabled  | String | `null` |
+| `app.persistence.existingClaim.static` | Name of the pvc for the static data when existingClaim is enabled  | String | `null` |
 | `app.persistence.existingClaim.enabled` | Whether to use a existing persistent storage claim. If `false`, the options from below are ignored | Boolean | `false` |
 | `app.persistence.storageClass` | StorageClass for the PVCs | String | `""` |
 | `app.persistence.accessModes` | Access modes for the PVCs | Array | `["ReadWriteMany"]` |

--- a/README.md
+++ b/README.md
@@ -61,6 +61,15 @@ For additional configuration of the Bitnami PostgreSQL and Redis, please check t
 | `app.global.annotations` | Annotations to attach to each resource, apart from the ingress and the persistence objects | Dictionary | `{}` |
 | `app.global.replicas` | Number of webserver instances that should be running. | Integer | `1` |
 
+### Nginx
+
+| Name | Description | Type | Default Value |
+|------|-------------|------|---------------|
+| `app.nginx.enabled` | Enable nginx as a proxy. This will enable persistent volumes, gunicorn and disable `DJANGO_DEBUG` | Boolean | `false` |
+| `app.nginx.image` | Image to use for the nginx proxy | String | `nginx:stable` |
+| `app.nginx.imagePullPolicy` | [Pull policy](https://kubernetes.io/docs/concepts/containers/images/#image-pull-policy) to use for the image | String | `IfNotPresent` |
+
+
 ### Ingress
 
 | Name | Description | Type | Default Value |

--- a/README.md
+++ b/README.md
@@ -83,10 +83,14 @@ For additional configuration of the Bitnami PostgreSQL and Redis, please check t
 | Name | Description | Type | Default Value |
 |------|-------------|------|---------------|
 | `app.persistence.enabled` | Whether to enable persistent storage. If `false`, the options from below are ignored | Boolean | `false` |
+| `app.persistence.existingClaim.media` | Name of the pvc for the media data when existingClaim is enabled  | String | `Nil` |
+| `app.persistence.existingClaim.static` | Name of the pvc for the static data when existingClaim is enabled  | String | `Nil` |
+| `app.persistence.existingClaim.enabled` | Whether to use a existing persistent storage claim. If `false`, the options from below are ignored | Boolean | `false` |
 | `app.persistence.storageClass` | StorageClass for the PVCs | String | `""` |
 | `app.persistence.accessModes` | Access modes for the PVCs | Array | `["ReadWriteMany"]` |
 | `app.persistence.size` | PVC size | String | `8Gi` |
 | `app.persistence.annotations` | Annotations to attach to the persistence objects (PVC and PV) | Dictionary | `{}` |
+| `app.persistence.enabled` | Whether to enable persistent storage. If `false`, the options from below are ignored | Boolean | `false` |
 
 ### Application Resources
 

--- a/charts/wger/Chart.yaml
+++ b/charts/wger/Chart.yaml
@@ -1,6 +1,6 @@
 ---
 apiVersion: v2
-version: 0.1.3
+version: 0.1.4-rc.2
 appVersion: 2.1.0
 name: wger
 description: A Helm chart for Wger installation on Kubernetes

--- a/charts/wger/templates/configmap.yml
+++ b/charts/wger/templates/configmap.yml
@@ -1,0 +1,46 @@
+{{- if .Values.app.nginx.enabled }}
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: {{ .Release.Name }}-nginx-configmap
+data:
+  wger-app.conf: |
+    upstream app_server {
+      server localhost:8000 fail_timeout=0;
+    }
+
+    server {
+      listen 8080;
+      client_max_body_size 4G;
+
+      # set the correct host(s) for your site
+      server_name {{ join " " .Values.ingress.url }};
+
+      access_log /var/log/nginx/access.log combined;
+      error_log  /var/log/nginx/error.log warn;
+
+      keepalive_timeout 5;
+
+      # path for static files (only needed for serving "local" static and media files)
+      root /var/www/html/;
+
+      location / {
+        # checks for static file, if not found proxy to app
+        try_files $uri @proxy_to_app;
+      }
+
+      location @proxy_to_app {
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header Host $http_host;
+
+        proxy_redirect off;
+        proxy_pass http://app_server;
+      }
+
+      error_page 500 502 503 504 /500.html;
+      location = /500.html {
+        root /var/www/html/;
+      }
+    }
+{{- end }}

--- a/charts/wger/templates/deployment.yaml
+++ b/charts/wger/templates/deployment.yaml
@@ -93,12 +93,12 @@ spec:
             - -c
             - until nc -zvw10 {{.Release.Name}}-postgresql {{ .Values.postgresql.global.postgresql.service.ports.postgresql }}; do echo "Waiting for postgres service ({{.Release.Name}}-postgresql:{{ .Values.postgresql.global.postgresql.service.ports.postgresql }}) "; sleep 2; done &&
               until nc -zvw10 {{.Release.Name}}-redis-master {{ .Values.redis.master.containerPort }}; do echo "Waiting for redis service ({{.Release.Name}}-redis-master:{{ .Values.redis.master.containerPort }})"; sleep 2; done
-      {{- if or (.Values.app.persistence.enabled) (.Values.app.existingClaim.enabled) }}
+      {{- if .Values.app.persistence.enabled }}
       volumes:
         - name: wger-media
           persistentVolumeClaim:
-            claimName: {{ .Values.app.existingClaim.media | default "wger-media" | quote }}
+            claimName: {{ .Values.app.persistence.existingClaim.media | default "wger-media" | quote }}
         - name: wger-static
           persistentVolumeClaim:
-            claimName: {{ .Values.app.existingClaim.static | default "wger-static" | quote }}
+            claimName: {{ .Values.app.persistence.existingClaim.static | default "wger-static" | quote }}
       {{- end }}

--- a/charts/wger/templates/deployment.yaml
+++ b/charts/wger/templates/deployment.yaml
@@ -93,12 +93,12 @@ spec:
             - -c
             - until nc -zvw10 {{.Release.Name}}-postgresql {{ .Values.postgresql.global.postgresql.service.ports.postgresql }}; do echo "Waiting for postgres service ({{.Release.Name}}-postgresql:{{ .Values.postgresql.global.postgresql.service.ports.postgresql }}) "; sleep 2; done &&
               until nc -zvw10 {{.Release.Name}}-redis-master {{ .Values.redis.master.containerPort }}; do echo "Waiting for redis service ({{.Release.Name}}-redis-master:{{ .Values.redis.master.containerPort }})"; sleep 2; done
-      {{- if .Values.app.persistence.enabled }}
+      {{- if or (.Values.app.persistence.enabled) (.Values.app.existingClaim.enabled) }}
       volumes:
         - name: wger-media
           persistentVolumeClaim:
-            claimName: wger-media
+            claimName: {{ .Values.app.existingClaim.media | default "wger-media" | quote }}
         - name: wger-static
           persistentVolumeClaim:
-            claimName: wger-static
+            claimName: {{ .Values.app.existingClaim.static | default "wger-static" | quote }}
       {{- end }}

--- a/charts/wger/templates/deployment.yaml
+++ b/charts/wger/templates/deployment.yaml
@@ -115,18 +115,6 @@ spec:
             - name: wger-static
               mountPath: /var/www/html/static
               readOnly: true
-          readinessProbe:
-            httpGet:
-              path: /
-              port: 8080
-            initialDelaySeconds: 3
-            periodSeconds: 3
-          livenessProbe:
-            httpGet:
-              path: /
-              port: 8080
-            initialDelaySeconds: 160
-            periodSeconds: 30
           resources:
             requests:
               cpu: 10m

--- a/charts/wger/templates/deployment.yaml
+++ b/charts/wger/templates/deployment.yaml
@@ -39,7 +39,7 @@ spec:
             limits:
               memory: {{ .Values.app.resources.limits.memory }}
               cpu: {{ .Values.app.resources.limits.cpu }}
-          {{- if .Values.app.persistence.enabled }}
+          {{- if or (.Values.app.persistence.enabled) (.Values.app.nginx.enabled) }}
           volumeMounts:
             - name: wger-media
               mountPath: /home/wger/media
@@ -49,7 +49,7 @@ spec:
               readOnly: false
           {{- end }}
           ports:
-            - containerPort: 8080
+            - containerPort: 8000
           env:
             - name: DJANGO_DB_ENGINE
               value: "django.db.backends.postgresql"
@@ -71,8 +71,13 @@ spec:
               value: django_redis.client.DefaultClient
             - name: DJANGO_CACHE_TIMEOUT
               value: "10"
+            {{- if .Values.app.nginx.enabled }}
+            - name: DJANGO_DEBUG
+              value: "False"
+            {{- else }}
             - name: DJANGO_DEBUG
               value: "True"
+            {{- end }}
             - name: DJANGO_MEDIA_ROOT
               value: /home/wger/media
             - name: SECRET_KEY
@@ -80,6 +85,10 @@ spec:
                 secretKeyRef:
                   name: {{ .Values.app.django.secret.name | default .Release.Name }}
                   key: secret-key
+            {{- if .Values.app.nginx.enabled }}
+            - name: WGER_USE_GUNICORN
+              value: "True"
+            {{- end }}
             {{- if .Values.ingress.enabled }}
             - name: SITE_URL
               value: {{ .Values.ingress.url }}
@@ -90,6 +99,38 @@ spec:
               value: {{ .value | quote }}
           {{- end }}
         {{- end }}
+        {{- if .Values.app.nginx.enabled }}
+        - name: nginx
+          image: {{ .Values.app.nginx.image }}
+          imagePullPolicy: {{ .Values.app.nginx.imagePullPolicy }}
+          ports:
+            - containerPort: 8080
+              protocol: TCP
+          volumeMounts:
+            - name: nginx-conf
+              mountPath: /etc/nginx/conf.d/
+            - name: wger-media
+              mountPath: /var/www/html/media
+              readOnly: true
+            - name: wger-static
+              mountPath: /var/www/html/static
+              readOnly: true
+          readinessProbe:
+            httpGet:
+              path: /
+              port: 8080
+            initialDelaySeconds: 3
+            periodSeconds: 3
+          livenessProbe:
+            httpGet:
+              path: /
+              port: 8080
+            initialDelaySeconds: 160
+            periodSeconds: 30
+          resources:
+            requests:
+              cpu: 10m
+        {{- end }}
       initContainers:
         - name: init-container
           image: docker.io/busybox:latest
@@ -98,12 +139,17 @@ spec:
             - -c
             - until nc -zvw10 {{.Release.Name}}-postgresql {{ .Values.postgresql.global.postgresql.service.ports.postgresql }}; do echo "Waiting for postgres service ({{.Release.Name}}-postgresql:{{ .Values.postgresql.global.postgresql.service.ports.postgresql }}) "; sleep 2; done &&
               until nc -zvw10 {{.Release.Name}}-redis-master {{ .Values.redis.master.containerPort }}; do echo "Waiting for redis service ({{.Release.Name}}-redis-master:{{ .Values.redis.master.containerPort }})"; sleep 2; done
-      {{- if .Values.app.persistence.enabled }}
       volumes:
+        {{- if or (.Values.app.persistence.enabled) (.Values.app.nginx.enabled) }}
         - name: wger-media
           persistentVolumeClaim:
             claimName: {{ .Values.app.persistence.existingClaim.media | default "wger-media" | quote }}
         - name: wger-static
           persistentVolumeClaim:
             claimName: {{ .Values.app.persistence.existingClaim.static | default "wger-static" | quote }}
-      {{- end }}
+        {{- end }}
+        {{- if .Values.app.nginx.enabled }}
+        - name: nginx-conf
+          configMap:
+            name: {{ .Release.Name }}-nginx-configmap
+        {{- end }}

--- a/charts/wger/templates/deployment.yaml
+++ b/charts/wger/templates/deployment.yaml
@@ -75,6 +75,11 @@ spec:
               value: "True"
             - name: DJANGO_MEDIA_ROOT
               value: /home/wger/media
+            - name: SECRET_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.app.django.secret.name | default .Release.Name }}
+                  key: secret-key
             {{- if .Values.ingress.enabled }}
             - name: SITE_URL
               value: {{ .Values.ingress.url }}

--- a/charts/wger/templates/persistent-volume-claim.yaml
+++ b/charts/wger/templates/persistent-volume-claim.yaml
@@ -1,5 +1,6 @@
 # yamllint disable rule:document-start
 {{- if .Values.app.persistence.enabled }}
+{{- if not .Values.app.persistence.existingClaim.enabled }}
 ---
 apiVersion: v1
 kind: PersistentVolumeClaim
@@ -44,4 +45,5 @@ spec:
   {{- if .Values.app.persistence.storageClass }}
   storageClassName:  {{ .Values.app.persistence.storageClass | quote }}
   {{- end }}
+{{- end }}
 {{- end }}

--- a/charts/wger/templates/persistent-volume-claim.yaml
+++ b/charts/wger/templates/persistent-volume-claim.yaml
@@ -1,5 +1,5 @@
 # yamllint disable rule:document-start
-{{- if .Values.app.persistence.enabled }}
+{{- if or (.Values.app.persistence.enabled) (.Values.app.nginx.enabled) }}
 {{- if not .Values.app.persistence.existingClaim.enabled }}
 ---
 apiVersion: v1

--- a/charts/wger/templates/secret-django.yaml
+++ b/charts/wger/templates/secret-django.yaml
@@ -2,11 +2,11 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: django
+  name: {{ .Values.app.django.secret.name | default .Release.Name }}
   namespace: {{ .Release.Namespace }}
 stringData:
-  {{ if .Values.app.django.secretKey }}
-  secret-key: {{ .Values.app.django.secretKey | b64enc | quote }}
+  {{ if .Values.app.django.secret.secretKey }}
+  secret-key: {{ .Values.app.django.secret.secretKey | quote }}
   {{ else }}
-  secret-key: {{ randAlphaNum 32 | b64enc | quote }}
+  secret-key: {{ randAlphaNum 42 | quote }}
   {{ end }}

--- a/charts/wger/templates/secret-django.yaml
+++ b/charts/wger/templates/secret-django.yaml
@@ -1,0 +1,12 @@
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: django
+  namespace: {{ .Release.Namespace }}
+stringData:
+  {{ if .Values.app.django.secretKey }}
+  secret-key: {{ .Values.app.django.secretKey | b64enc | quote }}
+  {{ else }}
+  secret-key: {{ randAlphaNum 32 | b64enc | quote }}
+  {{ end }}

--- a/charts/wger/templates/service.yaml
+++ b/charts/wger/templates/service.yaml
@@ -18,6 +18,10 @@ spec:
     - name: http
       protocol: TCP
       port: {{ .Values.service.port }}
+      {{- if .Values.app.nginx.enabled }}
+      targetPort: 8080
+      {{- else }}
       targetPort: 8000
+      {{- end }}
   selector:
     app.kubernetes.io/name: {{ .Release.Name }}-app

--- a/charts/wger/values.yaml
+++ b/charts/wger/values.yaml
@@ -13,10 +13,10 @@ app:
       - ReadWriteMany
     size: 8Gi
     annotations: {}
-  existingClaim:
-    enabled: false
-    media: null
-    static: null
+    existingClaim:
+      enabled: false
+      media: null
+      static: null
   resources:
     requests:
       memory: 128Mi

--- a/charts/wger/values.yaml
+++ b/charts/wger/values.yaml
@@ -24,6 +24,12 @@ app:
     limits:
       memory: 512Mi
       cpu: 500m
+  # when nginx is enabled persistent volumes are required
+  # and therefore automatically enabled
+  nginx:
+    enabled: false
+    image: nginx:stable
+    imagePullPolicy: IfNotPresent
   django:
     secret:
       name: null # if not set .Release.Name is set
@@ -45,8 +51,6 @@ app:
       value: None
     - name: FROM_EMAIL
       value: test@test.com
-    - name: WGER_USE_GUNICORN
-      value: "False"
     - name: SYNC_EXERCISES_ON_STARTUP
       value: "False"
     - name: DOWNLOAD_EXERCISE_IMAGES_ON_STARTUP

--- a/charts/wger/values.yaml
+++ b/charts/wger/values.yaml
@@ -24,6 +24,8 @@ app:
     limits:
       memory: 512Mi
       cpu: 500m
+  django:
+    secretKey: null # if not set a random one is generated
   environment:
     - name: TIME_ZONE
       value: UTC
@@ -41,6 +43,25 @@ app:
       value: None
     - name: FROM_EMAIL
       value: test@test.com
+    - name: WGER_USE_GUNICORN
+      value: "False"
+    - name: SYNC_EXERCISES_ON_STARTUP
+      value: "False"
+    - name: DOWNLOAD_EXERCISE_IMAGES_ON_STARTUP
+      value: "False"
+    - name: ALLOW_REGISTRATION
+      value: "False"
+    - name: ALLOW_GUEST_USERS
+      value: "False"
+    - name: SECRET_KEY
+      valueFrom:
+        secretKeyRef:
+          name: django
+          key: secret-key
+    - name: CSRF_TRUSTED_ORIGINS
+      value: "http://127.0.0.1,http://localhost,https://localhost"
+    - name: DJANGO_DEBUG
+      value: "False"
 
 ingress:
   enabled: false

--- a/charts/wger/values.yaml
+++ b/charts/wger/values.yaml
@@ -15,8 +15,8 @@ app:
     annotations: {}
     existingClaim:
       enabled: false
-      media: null
-      static: null
+      media: null # if not set wger-media is taken
+      static: null # if not set wger-static is taken
   resources:
     requests:
       memory: 128Mi
@@ -25,7 +25,9 @@ app:
       memory: 512Mi
       cpu: 500m
   django:
-    secretKey: null # if not set a random one is generated
+    secret:
+      name: null # if not set .Release.Name is set
+      secretKey: null # if not set a random one is generated
   environment:
     - name: TIME_ZONE
       value: UTC
@@ -53,15 +55,8 @@ app:
       value: "False"
     - name: ALLOW_GUEST_USERS
       value: "False"
-    - name: SECRET_KEY
-      valueFrom:
-        secretKeyRef:
-          name: django
-          key: secret-key
     - name: CSRF_TRUSTED_ORIGINS
       value: "http://127.0.0.1,http://localhost,https://localhost"
-    - name: DJANGO_DEBUG
-      value: "False"
 
 ingress:
   enabled: false

--- a/charts/wger/values.yaml
+++ b/charts/wger/values.yaml
@@ -13,6 +13,10 @@ app:
       - ReadWriteMany
     size: 8Gi
     annotations: {}
+  existingClaim:
+    enabled: false
+    media: null
+    static: null
   resources:
     requests:
       memory: 128Mi


### PR DESCRIPTION
Sorry, i based this branch upon my previous pull request. So support for `existingClaims` and django `SecretKey` is also in this pull request.

This will give the possibility to enable nginx, which will disable `debug` settings and enable `gunicorn`.