### PR TITLE
Release 0.2.0

### DIFF
--- a/charts/wger/Chart.yaml
+++ b/charts/wger/Chart.yaml
@@ -1,6 +1,6 @@
 ---
 apiVersion: v2
-version: 0.2.0-rc.2
+version: 0.2.0
 appVersion: latest
 name: wger
 description: A Helm chart for Wger installation on Kubernetes

--- a/charts/wger/Chart.yaml
+++ b/charts/wger/Chart.yaml
@@ -1,6 +1,6 @@
 ---
 apiVersion: v2
-version: 0.2.0-rc.1
+version: 0.2.0-rc.2
 appVersion: latest
 name: wger
 description: A Helm chart for Wger installation on Kubernetes

--- a/charts/wger/templates/_helpers.tpl
+++ b/charts/wger/templates/_helpers.tpl
@@ -24,6 +24,9 @@ environment:
     value: "test@test.com"
   - name: EMAIL_BACKEND
     value: "django.core.mail.backends.console.EmailBackend"
+  # Set your name and email to be notified if an internal server error occurs.
+  #- name: DJANGO_ADMINS
+  #  value: "SysAdmin, admin@test.com"
   # django db
   - name: DJANGO_PERFORM_MIGRATIONS
     value: "True"

--- a/charts/wger/templates/configmap.yaml
+++ b/charts/wger/templates/configmap.yaml
@@ -19,9 +19,15 @@ data:
       keepalive 2;
     }
 
+    # if no Host match, close the connection to prevent host spoofing
+    server {
+      listen 80 default_server;
+      return 444;
+    }
+
     # webserver
     server {
-      listen 8080;
+      listen 8080 deferred;
       client_max_body_size 4G;
 
       # set the correct host(s) for your site
@@ -58,17 +64,11 @@ data:
         proxy_buffers 64 4k;
         proxy_max_temp_file_size 0;
 
-        # send 500 when timeout
-        proxy_next_upstream error timeout http_500;
+        # give gunicorn time to process
+        proxy_read_timeout 1800;
 
         proxy_redirect off;
         proxy_pass http://app_server;
-      }
-
-      # error handling
-      error_page 500 502 503 504 /500.html;
-      location = /500.html {
-        root /var/www/html/;
       }
     }
 {{- end }}

--- a/example/prod_values.yaml
+++ b/example/prod_values.yaml
@@ -49,6 +49,8 @@ app:
       value: "XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX"
     - name: FROM_EMAIL
       value: "fit@example.com"
+    - name: DJANGO_ADMINS
+      value: "SysAdmin, admin@test.com
     - name: GUNICORN_CMD_ARGS
       value: "--timeout 240 --workers 2 --worker-class gthread --threads 3 --forwarded-allow-ips * --proxy-protocol True --access-logformat='%(h)s %(l)s %({client-ip}i)s %(l)s %({x-real-ip}i)s %(l)s %({x-forwarded-for}i)s %(l)s %(t)s \"%(r)s\" %(s)s %(b)s \"%(f)s\" \"%(a)s\"' --access-logfile - --error-logfile -"
 


### PR DESCRIPTION
* redis upgrade
* postgres minor upgrade
* setting a redis password is now possible
* remove inexistent 500 error page config in nginx
* increase proxy timeout for gunicorn
* mention DJANGO_ADMINS environment variable

### Upgrade

#### Postgres values change

Upgraded chart from groundhog2k for postgres requires changes to the `values.yml`:

```yaml
postgres:
  settings:
    superuser:
      value: postgres
    superuserPassword:
      value: XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
  userDatabase:
    name:
      value: wger
    user:
      value: wger
    password:
      value: XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
```

#### Redis password

When enabling the redis password after the installation (upgrade), it is required to set the password once in the `values.yml`, as soon as the secret is created it can be removed.

```yaml
redis:
  auth:
    enabled: true
    password: XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
```

Enabling redis authentication, requires you to set the following `env` and `args`, for the redis container:

```yaml
redis:
  auth:
    enabled: true
  # Additional environment variables (Redis server and Sentinel)
  env:
    - name: REDIS_PASSWORD
      valueFrom:
        secretKeyRef:
          name: redis
          key: redis-password
  # Arguments for the container entrypoint process (Redis server)
  args:
    - "--requirepass $(REDIS_PASSWORD)"
```